### PR TITLE
Replace local path with version for npm package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@fnando/sparkline": "^0.3.10",
     "@kickscondor/elasticlunr": "^0.9.8",
-    "@kickscondor/router": "file:../router",
+    "@kickscondor/router": "^0.7.2",
     "@shelacek/ubjson": "^1.0.1",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
Hi Kicks!

I noticed while trying to set this up locally that one of the NPM packages (specifically, router) was being looked for in a local path, so I changed it to the version [here](https://www.npmjs.com/package/@kickscondor/router) and that seems to have made the install work.