### PR TITLE
More descriptive delete message

### DIFF
--- a/src/js/follows.js
+++ b/src/js/follows.js
@@ -92,7 +92,7 @@ export default ({
     // Delete confirmation event from HTML.
     //
     confirmRemove: follow => ({local}, {location}) => {
-      if (confirm("Delete " + follow.url + "?")) {
+      if (confirm("Delete " + follow.title + "?\n" + "URL:" + follow.url)) {
         local.command("remove", follow)
       }
     },


### PR DESCRIPTION
Thought I'd make the confirmation of deleting a follow a bit more descriptive. This shows the title as well as the URL before deletion.