### PR TITLE
Prevent scrollbar from jiggling page

### DIFF
--- a/src/css/fraidy.scss
+++ b/src/css/fraidy.scss
@@ -85,6 +85,10 @@ $themes: (
   @return map-get($theme-map, $key);
 }
 
+html {
+  overflow-y: scroll;
+}
+
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
This fix prevents the page from shifting it's width when switching between tags that require a scrollbar vs. ones that don't.