### PR TITLE
Fix #97 by preventing button from triggering onSubmit event

### DIFF
--- a/src/js/view.js
+++ b/src/js/view.js
@@ -152,7 +152,7 @@ const FollowForm = (match, setup, isNew) => ({follows}, actions) => {
       </div>}
 
     <button onclick={e => {u('#working').attr('style', 'display: block'); return actions.follows.save(follow)}}>Save</button>
-    {!isNew && <button class="delete" onclick={_ => actions.follows.confirmRemove(follow)}>Delete This</button>}
+    {!isNew && <button type="button" class="delete" onclick={_ => actions.follows.confirmRemove(follow)}>Delete This</button>}
 
     <div id="working">
       <div>


### PR DESCRIPTION
Hi there,
I recently found out this project and stumbled on the bug described in #97. Since the codebase is relatively small, I decided it would not be too hard to find how to fix the issue (I am not a web dev).
The bug in question is fixed by giving the 'button' type to the delete button, so that the form is not submitted and therefore not frozen (corresponding [SO post](https://stackoverflow.com/questions/932653/how-to-prevent-buttons-from-submitting-forms)). Just tell me if this is not the right way to do this and I'll make changes.
Cheers!