### PR TITLE
manifest.json: fix instagram on Firefox

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -33,8 +33,18 @@
       "64": "images/flatcat-64.png"
     }
   },
-  "permissions": ["http://*/", "https://*/", "storage", "tabs",
-    "unlimitedStorage", "webRequest", "webRequestBlocking"],
+  "permissions": [
+    "http://*/",
+    "https://*/",
+    "https://instagram.com/*",
+    "https://www.instagram.com/*",
+    "storage",
+    "tabs",
+    "unlimitedStorage",
+    "webRequest",
+    "webRequestBlocking"
+  ],
+
 
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
This will fix #96. It won't fix #26 as I didn't add reddit or twitter.

The correct solution is to add all the domain roots from [`social.json`](https://github.com/kickscondor/fraidycat/blob/master/defs/social.json) to the manifest. IMHO, it should be a build step.

Another thought: investigate using [`optional_permissions`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions) to reduce the total number of permissions granted at once.