### PR TITLE
Make tags bar swipeable on mobile

### DIFF
--- a/src/css/fraidy.scss
+++ b/src/css/fraidy.scss
@@ -299,6 +299,8 @@ div.intro {
     ul {
       white-space: nowrap;
       margin-top: 4px;
+      overflow-y: scroll;
+      scrollbar-width: none;
 
       @include themed() {
         border-bottom: solid 8px t('border');

--- a/src/css/fraidy.scss
+++ b/src/css/fraidy.scss
@@ -87,6 +87,13 @@ $theme-map: null;
   @return map-get($theme-map, $key);
 }
 
+@supports (scrollbar-width: none){
+  #follows #tags > ul{
+    overflow-y: scroll;
+    scrollbar-width: none;
+  } 
+}
+
 html {
   overflow-y: scroll;
 }
@@ -299,8 +306,6 @@ div.intro {
     ul {
       white-space: nowrap;
       margin-top: 4px;
-      overflow-y: scroll;
-      scrollbar-width: none;
 
       @include themed() {
         border-bottom: solid 8px t('border');


### PR DESCRIPTION
Not entirely sure this interacts that well with the existing buttons. Not actually tested it on a mobile device but it seems to work well enough in the Firefox devtools mobile emulation thingy.