### PR TITLE
Convert title's html to text

### DIFF
--- a/src/js/view.js
+++ b/src/js/view.js
@@ -292,6 +292,7 @@ const Favicon = function(baseHref, follow) {
 const TitleMaxlen = 60, TitleMinlen = 24
 const TitleTruncRe = new RegExp(`([-,.!;:)]\s[^-,.!;:]{0,${TitleMaxlen - TitleMinlen}}|\\s\\S*)$`)
 const TitleTrunc = function(title) {
+  title = html2text(title)
   if (title.length < TitleMaxlen)
     return title
   let res = title.slice(0, TitleMaxlen).match(TitleTruncRe)


### PR DESCRIPTION
Hi,

I found that tweets which contain &"<> characters where being shown with those characters escaped. This might not be the ideal solution, but I tested it and it works for me. If you are not happy with this commit, please let me know and I can try changing it.

Git commit comment:
Stops the title from displaying html entities. Instead, html entities are displayed as the correct characters they represent.