### PR TITLE
Center "+" within the Add a Follow button

### DIFF
--- a/src/css/fraidy.scss
+++ b/src/css/fraidy.scss
@@ -178,6 +178,10 @@ div.intro {
       border-radius: 18px;
       font-weight: bold;
       color: white;
+
+      img {
+        margin: -1px 0px;
+      }
     }
   }
 }
@@ -270,7 +274,7 @@ div.intro {
         }
       }
     }
-    
+
     &:last-child {
       border-bottom: none;
     }
@@ -710,7 +714,7 @@ div.intro {
             color: t('button');
           }
         }
-        
+
         &:last-child::after {
           content: "";
         }
@@ -752,7 +756,7 @@ div.intro {
     list-style: none;
     margin: 0;
     padding: 0;
-    
+
     & > li {
       border-bottom: dotted 1px #C77;
       padding-bottom: 8px;


### PR DESCRIPTION
This is a pretty small change, just adding a negative margin to center the `+` button. Not quite sure what CSS quirk caused it to be misaligned to begin with.

**Before**
![image](https://user-images.githubusercontent.com/35242550/95119872-86088880-0701-11eb-99e7-311ed93ce1dd.png)

**After**
![image](https://user-images.githubusercontent.com/35242550/95119829-75f0a900-0701-11eb-8c6f-430517717abe.png)

Tested on Chromium 85.