### PR TITLE
Add support for Patreon-hosted private RSS feeds

### DIFF
--- a/defs/social.json
+++ b/defs/social.json
@@ -395,6 +395,13 @@
     ]
   },
 
+  "patreon.com:rss": {
+    "match": "^patreon\\.com\\/rss\\/([^?]+)\\?auth=([^?]+)",
+    "arguments": [0, {"var": "creator"}, {"var": "authkey"}],
+    "url": "https://patreon.com/rss/$creator?auth=$authkey",
+    "accept": ["rss"]
+  },
+
   "pinboard.in:rss": {
     "match": "^pinboard\\.in\\/([^?]+)",
     "arguments": [0, {"var": "path"}],


### PR DESCRIPTION
Some content creators offer a private RSS feed through Patreon as a membership reward (eg: a bonus episode feed for a podcast). This adds a rule for that use case.

Full disclosure, I wasn't able to set up an environment that can build fraidycat, so it isn't tested; I only tested the regex.